### PR TITLE
Add feishu-share to community-plugins.json

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -18233,5 +18233,12 @@
     "author": "Rootiest",
     "description": "Extracts text from images using AI Vision models.",
     "repo": "rootiest/obsidian-ai-image-ocr"
+  },
+  {
+  "id": "feishu-share",
+  "name": "Feishu Share",
+  "author": "LazyZane",
+  "description": "Share Obsidian notes to Feishu Docs with full formatting, attachments, nested docs, and wiki targets.",
+  "repo": "LazyZane/feishushare"
   }
 ]


### PR DESCRIPTION
Add new plugin: Feishu Share

- id: feishu-share
- name: Feishu Share
- author: LazyZane
- repo: LazyZane/feishushare
- description: Share Obsidian notes to Feishu Docs with full formatting, attachments, nested docs, and wiki targets.
- version (release tag): 2.5.1 (assets include manifest.json and main.js)
- minAppVersion: 0.15.0

Please switch to **Preview** and select one of the following links:

* [Community Plugin](?template=plugin.md)
* [Community Theme](?template=theme.md)

